### PR TITLE
Detect readonly controls and disable in UI

### DIFF
--- a/guvcview/gui_gtk3_v4l2ctrls.c
+++ b/guvcview/gui_gtk3_v4l2ctrls.c
@@ -751,6 +751,7 @@ void gui_gtk3_update_controls_state()
 
 		/*update flags (enable disable)*/
 		if((current->control.flags & V4L2_CTRL_FLAG_GRABBED) ||
+            (current->control.flags & V4L2_CTRL_FLAG_READ_ONLY) ||
             (current->control.flags & V4L2_CTRL_FLAG_DISABLED))
         {
 			if(cur_widget->label)

--- a/guvcview/gui_qt5_v4l2ctrls.cpp
+++ b/guvcview/gui_qt5_v4l2ctrls.cpp
@@ -677,6 +677,7 @@ void MainWindow::gui_qt5_update_controls_state()
 
 		/*update flags (enable disable)*/
 		if((current->control.flags & V4L2_CTRL_FLAG_GRABBED) ||
+            (current->control.flags & V4L2_CTRL_FLAG_READ_ONLY) ||
             (current->control.flags & V4L2_CTRL_FLAG_DISABLED))
         {
 			if(thisone->label)


### PR DESCRIPTION
Readonly controls can only be set by the camera and read by the driver and application. Similar to disabled or grabbed controls, their user interface should be disabled.